### PR TITLE
Fix: reference implementation not a requirement

### DIFF
--- a/phep-0001.md
+++ b/phep-0001.md
@@ -18,8 +18,8 @@ This proposal is largely inspired in [python's PEPs](https://www.python.org/dev/
 
 # Description
 ## What is a PhEP?
-PhEP stands for *Pharo Enhancement Proposal*. A PhEP is a design document providing information to the Pharo community, describing a new feature for Pharo or its processes or environment. The PhEP should provide a concise technical specification of the feature, a reference implementation, and a rationale for the feature.  
-We intend PhEPs to be the primary mechanisms for proposing major new features, for collecting community input on an issue, and for documenting the design decisions that have gone into Pharo. The PhEP author is responsible for building consensus within the community, documenting dissenting opinions and providing implementation.  
+PhEP stands for *Pharo Enhancement Proposal*. A PhEP is a design document providing information to the Pharo community, describing a new feature for Pharo or its processes or environment. The PhEP should provide a concise technical specification of the feature, and a rationale for the feature. A reference implementation is not required at this stage.
+We intend PhEPs to be the primary mechanisms for proposing major new features, for collecting community input on an issue, and for documenting the design decisions that have gone into Pharo. The PhEP author is responsible for building consensus within the community, documenting dissenting opinions and providing the implementation.  
 Because the PhEPs are maintained as text files in a versioned repository, their revision history is the [historical record of the feature proposal](http://github.com/pharo-project/pheps).  
 
 ## PhEP Audience


### PR DESCRIPTION
The first step does not need an implementation yet (as often, it makes only sense to start the work if one knows that it will be accepted)