### PR TITLE
Added status

### DIFF
--- a/phep-0001.md
+++ b/phep-0001.md
@@ -3,6 +3,7 @@ PhEP {
 	#id: 0001,
 	#type: #process,
 	#title: 'PhEP Purpose and Guidelines',
+	#status: #integrated,
 	#authors: [ 'Esteban Lorenzano' ],
 	#created: '2021-07-15'
 }
@@ -32,6 +33,15 @@ There are four kinds of PhEP:
 **1, 2 and 3**: "Image", "VM" or "Ecosystem" PhEPs are similar in objective: describes a new feature or implementation (or a removal!) for Pharo, but affects a different place of what is considered "Pharo":  the "image" is what you can get in the "vanilla" image you download as Pharo, the "VM" are the proposals affecting the Pharo Virtual Machine and "Ecosystem" describe some feature that affect what is considered part of the Pharo Ecosystem (libraries, tools used to support developing with Pharo, etc.).  
 
 **4**: A "Process" PhEP describes a process surrounding Pharo, or proposes a change to (or an event in) a process. Process PhEPs are like standards PhEPs but apply to areas other than the Pharo environment itself. They may propose an implementation, but not to Pharo's codebase; they often require community consensus. Examples include procedures, guidelines, changes to the decision-making process, and changes to the tools or environment used in Pharo development.  
+
+## PhEP Status
+A PhEP can be in different status since its submission until it's implemented and put in production (see workflow below):
+  
+**discussion**: this PhEP has been submitted by its author and it's under revision and discussion by the board and the community.
+**rejected**: this PhEP has been rejected by the board or the community after discussion. See below *Reasons to reject a PhEP*.
+**accepted**: this PhEP has been accepted by the board or the community after discussion. The PhEP is not yet implemented or it is not integrated into the main Pharo repositories.
+**implemented**: this PhEP has been accepted and has an available implementation, not yet integrated into the main Pharo repositories. Potential testing and integration effort are required. It is possible to go directly from *discussion* to *implemented* if an implementation is available at the moment of the submission. 
+**integrated**: this PhEP has been accepted, implemented and integrated into the main Pharo repositories. *process* PhEPs that do not require automation support can go directly from *discussion* to *integrated*.
 
 ## PhEP Workflow
 ### What is an enhancement for Pharo?  
@@ -97,6 +107,7 @@ PhEP {
 	#id: 0,
 	#type: #process,
 	#title: 'PhEP Purpose and Guidelines',
+	#status: #integrated,	
 	#authors: [ 'Esteban Lorenzano' ], 
 	#created: '2021-09-15',
 	#replaces: nil
@@ -106,6 +117,7 @@ PhEP {
 - `id`: the number of the PhEP (it is zero for proposals, the right id will be assigned upon acceptance).
 - `type`: the type of the PhEP, it can be #process, #image, #vm, #ecosystem 
 - `title`: the title of the PhEP
+- `status`: the status of this PhEP. It can be #discussion, #rejected, #accepted, #implemented, #integrated.
 - `authors`: the author of the PhEP, since there can be more than one, this field is an array.
 - `created`: the date of creation in yyyy-mm-dd format.
 - `replaces`: the id of the PhEPs this PhEP replaces (optional) 

--- a/phep-0002.md
+++ b/phep-0002.md
@@ -3,6 +3,7 @@ PhEP {
 	#id: 0002,
 	#type: #process,
 	#title: 'Pharo Contribution Guidelines',
+	#status: #integrated,
 	#authors: [ 'Esteban Lorenzano', 'Christophe Demarey' ],
 	#created: '2021-10-25'
 }


### PR DESCRIPTION
## PhEP Status
A PhEP can be in different status since its submission until it's implemented and put in production (see workflow below):

**discussion**: this PhEP has been submitted by its author and it's under revision and discussion by the board and the community.
**rejected**: this PhEP has been rejected by the board or the community after discussion. See below *Reasons to reject a PhEP*.
**accepted**: this PhEP has been accepted by the board or the community after discussion. The PhEP is not yet implemented or it is not integrated into the main Pharo repositories.
**implemented**: this PhEP has been accepted and has an available implementation, not yet integrated into the main Pharo repositories. Potential testing and integration effort are required. It is possible to go directly from *discussion* to *implemented* if an implementation is available at the moment of the submission. 
**integrated**: this PhEP has been accepted, implemented and integrated into the main Pharo repositories. *process* PhEPs that do not require automation support can go directly from *discussion* to *integrated*.